### PR TITLE
emacs.sh: increase minimum version to 26

### DIFF
--- a/scripts/emacs.sh
+++ b/scripts/emacs.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-: "${minimum_version:=25.1}"
+: "${minimum_version:=26}"
 
 function _confirm() {
     read -r -p "${1:-Are you sure? [y/N]} " response


### PR DESCRIPTION
Bazel-mode requires version 26 or above.