### PR TITLE
Make Teams notifications float and not focus

### DIFF
--- a/dotfiles/.config/i3/config
+++ b/dotfiles/.config/i3/config
@@ -202,6 +202,9 @@ bindsym XF86AudioPause exec playerctl pause
 bindsym XF86AudioNext exec playerctl next
 bindsym XF86AudioPrev exec playerctl previous
 
+# Avoid MS Teams notifications to go to a new window and grab focus
+for_window [title="Microsoft Teams Notification"] floating enable, no_focus
+
 # Network Manager
 exec --no-startup-id nm-applet
 


### PR DESCRIPTION
MS Teams for Linux is not written in a Linux native manner
and therefore does not work well with any window manager, especially
not with tiling ones.

Since MS app is nicer for calls, this change makes the notification
at least not show as a full window. For all other purposes, the
non-official app written by a sole developer is still clearly better
than MSs own.