### PR TITLE
i3: change i3exit key

### DIFF
--- a/dotfiles/.config/i3/config
+++ b/dotfiles/.config/i3/config
@@ -169,7 +169,7 @@ mode "$mode_system" {
     bindsym Return mode "default"
     bindsym Escape mode "default"
 }
-bindsym $mod+Pause mode "$mode_system"
+bindsym $mod+Delete mode "$mode_system"
 
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)


### PR DESCRIPTION
Pause button not available on some laptops, use Delete instead