### PR TITLE
bash: organize profile-files

### DIFF
--- a/dotfiles/.bash_profile
+++ b/dotfiles/.bash_profile
@@ -1,0 +1,10 @@
+# ~/.bash_profile
+# Source ~/.profile for environment variables
+if [ -f "$HOME/.profile" ]; then
+  . "$HOME/.profile"
+fi
+
+# Source ~/.bashrc for interactive features
+if [ -f "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi

--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -6,22 +6,13 @@
 
 # the default umask is set in /etc/profile; for setting the umask
 # for ssh logins, install and configure the libpam-umask package.
-#umask 022
+# umask 022
 
-# if running bash
-if [ -n "$BASH_VERSION" ]; then
-    # include .bashrc if it exists
-    if [ -f "$HOME/.bashrc" ]; then
-	. "$HOME/.bashrc"
-    fi
-fi
-
-# set PATH so it includes user's private bin if it exists
-if [ -d "$HOME/bin" ] ; then
-    PATH="$HOME/bin:$PATH"
-fi
-
-# set PATH so it includes user's private bin if it exists
+# include user-specific bin directories
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
+if [ -d "$HOME/bin" ] ; then
+    PATH="$HOME/bin:$PATH"
+fi
+export PATH


### PR DESCRIPTION
Adds .bash_profile for a more sensible setup

- .profile
  * contains settings for any shell
  * currently it sets user-specific bin directories
  * changed bin to take precedence over .local/bin
- .bash_profile
  * sources .profile
  * sources .bashrc to add interactive features to login shells