### PR TITLE
.bashrc: check if file when sourcing

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -13,7 +13,9 @@ config_dir="${HOME}/.config/bash"
 
 if [[ -d "${config_dir}" ]]; then
     for file in "${config_dir}"/*; do
-        source "${file}"
+        if [ -f "${file}" ]; then
+            source "${file}"
+        fi
     done
 fi
 
@@ -22,6 +24,8 @@ extra_config_dir="${HOME}/.config/bash/local"
 
 if [[ -d "${extra_config_dir}" ]]; then
     for file in "${extra_config_dir}"/*; do
-        source "${file}"
+        if [ -f "${file}" ]; then
+            source "${file}"
+        fi
     done
 fi


### PR DESCRIPTION
Add a check that it is a file when sourcing bash config. Prevents failures on subdirectories etc.