### PR TITLE
bash/exports.sh: don't add bin to path

### DIFF
--- a/dotfiles/.config/bash/03_exports.sh
+++ b/dotfiles/.config/bash/03_exports.sh
@@ -2,4 +2,3 @@
 
 export EDITOR="emacs -nw -q"
 export LESS=MdQiCR
-export PATH=$HOME/bin:$PATH


### PR DESCRIPTION
Removes addition of ${HOME}/bin to path as this is already done in .profile.