### PR TITLE
bash/exports.sh: store less history in XDG_STATE_HOME

### DIFF
--- a/dotfiles/.config/bash/03_exports.sh
+++ b/dotfiles/.config/bash/03_exports.sh
@@ -2,3 +2,4 @@
 
 export EDITOR="emacs -nw -q"
 export LESS=MdQiCR
+export LESSHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/less/history"


### PR DESCRIPTION
Moves the less history file away from ${HOME} to
under $XDG_STATE_HOME.