### PR TITLE
bash/exports.sh: fix coloring of other-writable dirs

### DIFF
--- a/dotfiles/.config/bash/03_exports.sh
+++ b/dotfiles/.config/bash/03_exports.sh
@@ -3,3 +3,4 @@
 export EDITOR="emacs -nw -q"
 export LESS=MdQiCR
 export LESSHISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/less/history"
+export LS_COLORS="${LS_COLORS}ow=1;97;45:"


### PR DESCRIPTION
Directories where others have write-rights had a default color that made the directory name poorly visible.