### PR TITLE
bash/asdf.sh: update according to version 0.16.0+

### DIFF
--- a/dotfiles/.config/bash/50_asdf.sh
+++ b/dotfiles/.config/bash/50_asdf.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if [[ -f "${HOME}"/.asdf/asdf.sh ]]; then
-    source "${HOME}"/.asdf/asdf.sh
-    source "${HOME}"/.asdf/completions/asdf.bash
+if [[ -x "$(command -v asdf)" ]]; then
+    export ASDF_DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/asdf"
+    export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+    . <(asdf completion bash)
 fi


### PR DESCRIPTION
Asdf had a major rewrite for version 0.16.0 where
it was translated to golang. Update setting of path and completion generation accordingly.