### PR TITLE
bash/fzf.sh: update initialition

### DIFF
--- a/dotfiles/.config/bash/70_fzf.sh
+++ b/dotfiles/.config/bash/70_fzf.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-if [[ -f "${HOME}"/.fzf.bash ]]; then
-    source ~/.fzf.bash
-
-    export FZF_DEFAULT_OPTS='-e'
+if [[ -x "$(command -v fzf)" ]]; then
+    eval "$(fzf --bash)"
+    export FZF_DEFAULT_OPTS='--exact'
 fi


### PR DESCRIPTION
From fzf version 0.48.0, shell integration is included in the binary itself, which can now run as a standalone. This commit updates the initialization accordingly.