### PR TITLE
bash: optimize history saving

### DIFF
--- a/dotfiles/.config/bash/03_exports.sh
+++ b/dotfiles/.config/bash/03_exports.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Put bash history file under XDG
+export HISTFILE="${XDG_STATE_HOME:-$HOME/.local/state}/bash/history"
 # Use emacs as default editor
 export EDITOR="emacs -nw -q"
 # Default less options

--- a/dotfiles/.config/bash/10_environment.sh
+++ b/dotfiles/.config/bash/10_environment.sh
@@ -11,6 +11,14 @@ shopt -s histappend
 HISTSIZE=10000
 HISTFILESIZE=20000
 
+# Immediately append each command to the history file, this way shells
+# won't overwrite each others history. The history file will be mixed
+# with commands from all shells but the purpose is not to preserve
+# the order but to have all commands stored and searchable with fzf.
+# To transfer a command written in one shell to another mid-shell
+# use history -r.
+PROMPT_COMMAND='history -a'
+
 # check the window size after each command and, if necessary,
 # update the values of LINES and COLUMNS.
 shopt -s checkwinsize
@@ -24,9 +32,6 @@ shopt -s checkwinsize
 
 # Do not list all commands when pressing tab on an empty line
 shopt -s no_empty_cmd_completion
-
-# Append to history file instead of overwriting
-shopt -s histappend
 
 # Features supported by version 4
 if [[ "${BASH_VERSINFO[0]}" -gt 3 ]]; then

--- a/dotfiles/.config/bash/25_functions.sh
+++ b/dotfiles/.config/bash/25_functions.sh
@@ -17,3 +17,18 @@ function less_newest()
 {
     find "$1" -maxdepth 1 -type "f" -printf "%T@ %p\n" | sort -n | cut -d' ' -f 2- | tail -n 1 | xargs less
 }
+
+# De-duplicates the bash history file
+function dedup_history() {
+    local histfile="${HISTFILE}"
+    local tmpfile="${histfile}.$$"
+
+    tac "${histfile}" | awk '!seen[$0]++' | tac > "${tmpfile}" && 'cp' -f "${histfile}" "${histfile}".bck && 'mv' -f "${tmpfile}" "${histfile}"
+}
+
+# Stuff to do on shell exit
+function on_exit() {
+    dedup_history # De-duplicate history file
+}
+
+trap on_exit EXIT


### PR DESCRIPTION
- store bash history under XDG
- add PROMPT_COMMAND for appending each command to history when it is written rather than waiting until the shell exits. This way shells won't overwrite each others history.
- add function for de-duplicating the bash history. This way there are no duplicates when searching history.
- de-duplicate the history when the shell exits