### PR TITLE
bash/fzf: add keyboard shortcuts for fzf searches

### DIFF
--- a/dotfiles/.config/bash/70_fzf.sh
+++ b/dotfiles/.config/bash/70_fzf.sh
@@ -2,5 +2,5 @@
 
 if [[ -x "$(command -v fzf)" ]]; then
     eval "$(fzf --bash)"
-    export FZF_DEFAULT_OPTS='--exact'
+    export FZF_DEFAULT_OPTS='--exact --ansi --bind home:first,end:last,ctrl-k:kill-line,alt-d:clear-query'
 fi


### PR DESCRIPTION
Adds some keyboard shortcuts that can be used in the fzf prompt